### PR TITLE
Implemented handling for remote targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,3 +106,19 @@ Then you can run the trace recording script with the profile like this:
 ```
 $ lttng-record-trace -p myprofile
 ```
+
+### Tracing on remote target
+With the following command line options lttng-record-trace can be used to interface a lttng session on a remote target.
+This is especially useful for embedded targets, where stuff like python might not be installed.
+And even if python is available, feature-rich frontends like [Trace Compass](https://eclipse.dev/tracecompass/) might not be available at all.
+The following options allow to specify an ssh connection to the target:
+
+```
+  --remote REMOTE        Remote target for tracing, use user@target
+  --port PORT            Remote target port
+  --password PASSWORD    Password for remote target connection
+  --private-key PRIV_KEY Private ssh key for remote target connection
+```
+
+When specifying a password, the tool [sshpass](https://linux.die.net/man/1/sshpass) needs to be present in your runtime environment.
+After the trace has been recorded, all trace files are downloaded via scp to the specified output folder and cleaned from the target afterwards.

--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ The following options allow to specify an ssh connection to the target:
   --password PASSWORD            Password for remote target connection
   --private-key PRIV_KEY         Private ssh key for remote target connection
   --remote-folder REMOTE_FOLDER  Temporary folder on remote target to store trace data. Default is /tmp/tracing
+  --remote-cleanup               Remove temporary folder on remote target after tracing is complete
 ```
 
 When specifying a password, the tool [sshpass](https://linux.die.net/man/1/sshpass) needs to be present in your runtime environment.

--- a/README.md
+++ b/README.md
@@ -114,10 +114,11 @@ And even if python is available, feature-rich frontends like [Trace Compass](htt
 The following options allow to specify an ssh connection to the target:
 
 ```
-  --remote REMOTE        Remote target for tracing, use user@target
-  --port PORT            Remote target port
-  --password PASSWORD    Password for remote target connection
-  --private-key PRIV_KEY Private ssh key for remote target connection
+  --remote REMOTE                Remote target for tracing, use user@target
+  --port PORT                    Remote target port
+  --password PASSWORD            Password for remote target connection
+  --private-key PRIV_KEY         Private ssh key for remote target connection
+  --remote-folder REMOTE_FOLDER  Temporary folder on remote target to store trace data. Default is /tmp/tracing
 ```
 
 When specifying a password, the tool [sshpass](https://linux.die.net/man/1/sshpass) needs to be present in your runtime environment.

--- a/lttng-record-trace
+++ b/lttng-record-trace
@@ -59,6 +59,7 @@ trace_running = True
 current = ""
 original_sigint = signal.getsignal(signal.SIGINT)
 lttngProfiles = profile.Profile()
+remote_out_path = "/tmp"
 
 default_profile = "kernel"
 evlist_search_path = [ os.path.join(os.getcwd(), "profiles/"),
@@ -66,9 +67,14 @@ evlist_search_path = [ os.path.join(os.getcwd(), "profiles/"),
                        "/usr/local/share/lttng-utils/profiles/",
                        "/usr/share/lttng-utils/profiles/" ]
 
+ssh_cmd = None
+scp_cmd = None
+
 def cmd_stub(cmds, check, cmd_env=None, with_shell=False):
     if cmd_env is None:
         cmd_env = os.environ
+    if (options.remote != None):
+        cmds = ssh_cmd.split() + cmds
     logging.debug("LD_PRELOAD=" + cmd_env.get("LD_PRELOAD", ""))
     logging.debug("exec: " + " ".join(cmds))
     retcode = 0
@@ -119,16 +125,21 @@ def do_trace(cmd, session, options):
         return
     if (profile["kernel"] or options.enable_all_events):
         # Check that the kernel tracer is available
-        if (lttng.check_kernel_tracer() == False):
+        if (lttng.check_kernel_tracer(ssh_cmd) == False):
             sys.exit(1)
         session += "-k"
     if (profile["ust"] or profile["jul"] or options.enable_all_events):
         # Check that the userspace tracer is available
-        if (lttng.check_ust_tracer() == False):
+        if (lttng.check_ust_tracer(ssh_cmd) == False):
             sys.exit(1)
         session += "-u"
     session += "-" + datetime.datetime.now().strftime("%Y%m%d-%H%M%S")
-    out = join(options.output, session)
+    out_local = join(options.output, session)
+    out_remote = join(remote_out_path, session)
+    if (options.remote != None):
+        out = out_remote
+    else:
+        out = out_local
     # generate random uuid
     current = session
 
@@ -203,8 +214,15 @@ def do_trace(cmd, session, options):
 
     # Step 6: Print trace path
     if not options.dry_run:
+        if (options.remote != None):
+            subprocess.call(["mkdir", "-p", out_local], stdout=log_stream, stderr=log_stream, env=cmd_env)
+            print("Downloading trace files from remote target")
+            copy_cmd = f"{scp_cmd}:{out_remote}/* {out_local}/".split()
+            subprocess.call(copy_cmd, stdout=log_stream, stderr=log_stream, env=cmd_env)
+            print("Removing trace files from remote target")
+            cmd_stub(["rm", "-rf", out_remote], False, cmd_env)
         print("")
-        print("The trace is available for analysis at " + out)
+        print("The trace is available for analysis at " + out_local)
 
 if __name__=="__main__":
     # default directory for traces
@@ -220,6 +238,10 @@ if __name__=="__main__":
     parser.add_argument("-a", "--all", dest="enable_all_events", default=False, action="store_true", help="Enable all events. This option has precedence over the selected profile")
     parser.add_argument("-n", "--dry-run", dest="dry_run", default=False, action="store_true", help="Outputs the commands without executing them. The output can be copied to a script and run")
     parser.add_argument("--stateless", dest="stateless", default=False, action="store_true", help="Enable pid/tid/procname context for stateless trace processing")
+    parser.add_argument("--remote", dest="remote", default=None, help="Remote target for tracing, use user@target")
+    parser.add_argument("--port", dest="port", default="22", help="Remote target port")
+    parser.add_argument("--password", dest="password", default=None, help="Password for remote target connection")
+    parser.add_argument("--private-key", dest="priv_key", default=None, help="Private ssh key for remote target connection")
     parser.add_argument("--name", dest="name", metavar="NAME", default=None, help="trace output name (default to command name with k/u suffix)")
     parser.add_argument('--verbose', '-v', action='count', dest="verbose", help="Verbose mode. The number of -v will increase verbosity of logging.")
     parser.add_argument('command', nargs=argparse.REMAINDER, help="The command to trace. It will be executed after the trace has started and the trace will terminate after its execution.")
@@ -234,6 +256,19 @@ if __name__=="__main__":
         lttngProfiles.print_profiles_detail(options.list_profile.split(","))
         sys.exit(0)
 
+    if (options.remote != None):
+        ssh_common_opts = f"-p {options.port} {options.remote}"
+        scp_common_opts = f"-P {options.port} -r {options.remote}"
+        if (options.priv_key == None):
+            if (options.password == None):
+                ssh_cmd = f"ssh {ssh_common_opts}"
+                scp_cmd = f"scp {scp_common_opts}"
+            else:
+                ssh_cmd = f"sshpass -p {options.password} ssh {ssh_common_opts}"
+                scp_cmd = f"sshpass -p {options.password} scp {scp_common_opts}"
+        else:
+                ssh_cmd = f"ssh -o \"IdentitiesOnly=yes\" -i {options.priv_key} {ssh_common_opts}"
+                scp_cmd = f"scp -i {options.priv_key} {scp_common_opts}"
     # try to create base directory if it doesn't exists
     if not os.path.exists(options.output):
         os.makedirs(options.output)
@@ -250,7 +285,7 @@ if __name__=="__main__":
 
     if (dry_run == False):
         # Check that a session daemon is running
-        if (lttng.check_sessiond() == False):
+        if (lttng.check_sessiond(ssh_cmd) == False):
             sys.exit(1)
 
     logger = logging.getLogger()

--- a/lttng-record-trace
+++ b/lttng-record-trace
@@ -135,9 +135,8 @@ def do_trace(cmd, session, options):
         session += "-u"
     session += "-" + datetime.datetime.now().strftime("%Y%m%d-%H%M%S")
     out_local = join(options.output, session)
-    out_remote = join(remote_out_path, session)
     if (options.remote != None):
-        out = out_remote
+        out = options.remote_folder
     else:
         out = out_local
     # generate random uuid
@@ -217,10 +216,10 @@ def do_trace(cmd, session, options):
         if (options.remote != None):
             subprocess.call(["mkdir", "-p", out_local], stdout=log_stream, stderr=log_stream, env=cmd_env)
             print("Downloading trace files from remote target")
-            copy_cmd = f"{scp_cmd}:{out_remote}/* {out_local}/".split()
+            copy_cmd = f"{scp_cmd}:{out}/* {out_local}/".split()
             subprocess.call(copy_cmd, stdout=log_stream, stderr=log_stream, env=cmd_env)
             print("Removing trace files from remote target")
-            cmd_stub(["rm", "-rf", out_remote], False, cmd_env)
+            cmd_stub(["rm", "-rf", out], False, cmd_env)
         print("")
         print("The trace is available for analysis at " + out_local)
 
@@ -242,6 +241,7 @@ if __name__=="__main__":
     parser.add_argument("--port", dest="port", default="22", help="Remote target port")
     parser.add_argument("--password", dest="password", default=None, help="Password for remote target connection")
     parser.add_argument("--private-key", dest="priv_key", default=None, help="Private ssh key for remote target connection")
+    parser.add_argument("--remote-folder", dest="remote_folder", default="/tmp/tracing", help="Temporary folder on remote target to store trace data. Default is /tmp/tracing")
     parser.add_argument("--name", dest="name", metavar="NAME", default=None, help="trace output name (default to command name with k/u suffix)")
     parser.add_argument('--verbose', '-v', action='count', dest="verbose", help="Verbose mode. The number of -v will increase verbosity of logging.")
     parser.add_argument('command', nargs=argparse.REMAINDER, help="The command to trace. It will be executed after the trace has started and the trace will terminate after its execution.")
@@ -257,7 +257,7 @@ if __name__=="__main__":
         sys.exit(0)
 
     if (options.remote != None):
-        ssh_common_opts = f"-p {options.port} {options.remote}"
+        ssh_common_opts = f"-t -p {options.port} {options.remote}"
         scp_common_opts = f"-P {options.port} -r {options.remote}"
         if (options.priv_key == None):
             if (options.password == None):

--- a/lttng-record-trace
+++ b/lttng-record-trace
@@ -60,6 +60,9 @@ current = ""
 original_sigint = signal.getsignal(signal.SIGINT)
 lttngProfiles = profile.Profile()
 remote_out_path = "/tmp"
+remote_out_path_cleanup_ignore_array = [
+    "/"
+]
 
 default_profile = "kernel"
 evlist_search_path = [ os.path.join(os.getcwd(), "profiles/"),
@@ -218,8 +221,12 @@ def do_trace(cmd, session, options):
             print("Downloading trace files from remote target")
             copy_cmd = f"{scp_cmd}:{out}/* {out_local}/".split()
             subprocess.call(copy_cmd, stdout=log_stream, stderr=log_stream, env=cmd_env)
-            print("Removing trace files from remote target")
-            cmd_stub(["rm", "-rf", out], False, cmd_env)
+            if options.remote_cleanup:
+                if out in remote_out_path_cleanup_ignore_array:
+                    print(f"Temporary output folder \"{out}\" found in ignore list, skipping cleanup!")
+                else:
+                    print("Removing trace files from remote target")
+                    cmd_stub(["rm", "-r", out], False, cmd_env)
         print("")
         print("The trace is available for analysis at " + out_local)
 
@@ -242,6 +249,7 @@ if __name__=="__main__":
     parser.add_argument("--password", dest="password", default=None, help="Password for remote target connection")
     parser.add_argument("--private-key", dest="priv_key", default=None, help="Private ssh key for remote target connection")
     parser.add_argument("--remote-folder", dest="remote_folder", default="/tmp/tracing", help="Temporary folder on remote target to store trace data. Default is /tmp/tracing")
+    parser.add_argument("--remote-cleanup", dest="remote_cleanup", default=False, action="store_true", help="Remove temporary folder on remote target after tracing is complete")
     parser.add_argument("--name", dest="name", metavar="NAME", default=None, help="trace output name (default to command name with k/u suffix)")
     parser.add_argument('--verbose', '-v', action='count', dest="verbose", help="Verbose mode. The number of -v will increase verbosity of logging.")
     parser.add_argument('command', nargs=argparse.REMAINDER, help="The command to trace. It will be executed after the trace has started and the trace will terminate after its execution.")

--- a/lttngutils/lttng.py
+++ b/lttngutils/lttng.py
@@ -31,8 +31,13 @@ __all__ = ["check_sessiond", "check_kernel_tracer", "check_ust_tracer"]
 # the lttng command
 LTTNG="lttng"
 
-def check_sessiond():
-    retcode = subprocess.call([LTTNG, "list"], stdout=open(os.devnull, 'wb'), stderr=open(os.devnull, 'wb'))
+def check_sessiond(remote=None):
+    cmd = [LTTNG, "list"]
+
+    if (remote != None):
+        cmd = remote.split() + cmd
+
+    retcode = subprocess.call(cmd, stdout=open(os.devnull, 'wb'), stderr=open(os.devnull, 'wb'))
     logging.debug("exit: " + str(retcode))
 
     if (retcode != 0):
@@ -66,8 +71,13 @@ def check_sessiond():
         return False
     return True
 
-def check_kernel_tracer():
-    retcode = subprocess.call([LTTNG, "list", "-k"], stdout=open(os.devnull, 'wb'), stderr=open(os.devnull, 'wb'))
+def check_kernel_tracer(remote=None):
+    cmd = [LTTNG, "list", "-k"]
+
+    if (remote != None):
+        cmd = remote.split() + cmd
+
+    retcode = subprocess.call(cmd, stdout=open(os.devnull, 'wb'), stderr=open(os.devnull, 'wb'))
     logging.debug("exit: " + str(retcode))
 
     if (retcode != 0):
@@ -82,8 +92,13 @@ def check_kernel_tracer():
         return False
     return True
 
-def check_ust_tracer():
-    retcode = subprocess.call([LTTNG, "list", "-u"], stdout=open(os.devnull, 'wb'), stderr=open(os.devnull, 'wb'))
+def check_ust_tracer(remote=None):
+    cmd = [LTTNG, "list", "-u"]
+
+    if (remote != None):
+        cmd = remote.split() + cmd
+
+    retcode = subprocess.call(cmd, stdout=open(os.devnull, 'wb'), stderr=open(os.devnull, 'wb'))
     logging.debug("exit: " + str(retcode))
 
     if (retcode != 0):


### PR DESCRIPTION
Hi,
I like to use lttng on embedded linux targets, that usually don't provide any python interpreter. Also, analyzing the traces later is much more convenient , when done on a more powerful device. As a result I added some functionality to handle remote targets and executed the lttng commands via ssh.
It's far from perfect, but in case you are interested, we can use this PR for discussion.